### PR TITLE
Upstream/14 feature artistrestcontroller

### DIFF
--- a/src/main/java/com/example/kspot/artists/controller/ArtistsController.java
+++ b/src/main/java/com/example/kspot/artists/controller/ArtistsController.java
@@ -1,0 +1,46 @@
+package com.example.kspot.artists.controller;
+
+import com.example.kspot.artists.service.ArtistsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/artists")
+public class ArtistsController {
+
+    private final ArtistsService artistsService;
+
+    public ArtistsController(ArtistsService artistsService) {
+        this.artistsService = artistsService;
+    }
+
+    @GetMapping()
+    public ResponseEntity<Map<String,Object>> getArtists() {
+
+        Map<String, Object> body = Map.of(
+                "status", 200,
+                "message", "아티스트 목록 조회 성공",
+                "data", Map.of("items", artistsService.getArtists())
+        );
+
+        return ResponseEntity.ok(body);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Map<String, Object>> getArtistById(@PathVariable Long id) {
+
+        Map<String, Object> body = Map.of(
+                "status", 200,
+                "message", "아티스트 조회 성공",
+                "data", artistsService.getArtistById(id)
+        );
+
+        return ResponseEntity.ok(body);
+    }
+
+}

--- a/src/main/java/com/example/kspot/artists/dto/ArtistsResponseDto.java
+++ b/src/main/java/com/example/kspot/artists/dto/ArtistsResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.kspot.artists.dto;
+
+import com.example.kspot.artists.entity.Artists;
+
+public record ArtistsResponseDto(
+        Long artistId,
+        String name,
+        String profileImageUrl
+) {
+    public static ArtistsResponseDto fromEntity(Artists artists) {
+        return new ArtistsResponseDto(
+                artists.getArtistId(),
+                artists.getName(),
+                artists.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/kspot/artists/entity/Artists.java
+++ b/src/main/java/com/example/kspot/artists/entity/Artists.java
@@ -36,4 +36,16 @@ public class Artists {
     public void setName(String name) {
         this.name = name;
     }
+
+    public Long getArtistId() {
+        return artistId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
 }

--- a/src/main/java/com/example/kspot/artists/repository/ArtistsRepository.java
+++ b/src/main/java/com/example/kspot/artists/repository/ArtistsRepository.java
@@ -2,5 +2,7 @@ package com.example.kspot.artists.repository;
 
 import com.example.kspot.artists.entity.Artists;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ArtistsRepository extends JpaRepository<Artists,Long> {}

--- a/src/main/java/com/example/kspot/artists/service/ArtistsService.java
+++ b/src/main/java/com/example/kspot/artists/service/ArtistsService.java
@@ -1,0 +1,34 @@
+package com.example.kspot.artists.service;
+
+import com.example.kspot.artists.dto.ArtistsResponseDto;
+import com.example.kspot.artists.entity.Artists;
+import com.example.kspot.artists.repository.ArtistsRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.kspot.artists.dto.ArtistsResponseDto.fromEntity;
+
+@Service
+public class ArtistsService {
+
+    private final ArtistsRepository artistsRepository;
+
+    public ArtistsService(ArtistsRepository artistsRepository) {
+        this.artistsRepository = artistsRepository;
+    }
+
+    public List<ArtistsResponseDto> getArtists() {
+        return artistsRepository.findAll().stream().map(ArtistsResponseDto::fromEntity).toList();
+    }
+
+    public ArtistsResponseDto getArtistById(Long id) {
+        return fromEntity(
+                artistsRepository.findById(id).orElseThrow(
+                        () -> new IllegalArgumentException("id값이 옳지 않습니다.")
+                )
+        );
+    }
+
+}

--- a/src/test/java/com/example/kspot/ArtistsControllerTest.java
+++ b/src/test/java/com/example/kspot/ArtistsControllerTest.java
@@ -1,0 +1,85 @@
+package com.example.kspot;
+
+import com.example.kspot.artists.controller.ArtistsController;
+import com.example.kspot.artists.dto.ArtistsResponseDto;
+import com.example.kspot.artists.service.ArtistsService;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@WebMvcTest(ArtistsController.class)
+class ArtistsControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockitoBean
+    ArtistsService artistsService;
+
+    @Test
+    void 전체_아티스트_조회() throws Exception {
+
+        // given
+        var items = List.of(
+            new ArtistsResponseDto(1L, "이지금", "https://image.url/profile.jpg"),
+            new ArtistsResponseDto(2L, "홍길동", "https://image.url/profile1.jpg")
+        );
+        given(artistsService.getArtists()).willReturn(items);
+
+        String expected = """
+            {
+              "status": 200,
+              "message": "아티스트 목록 조회 성공",
+              "data": { "items": [
+                { "artistId": 1, "name": "이지금", "profileImageUrl": "https://image.url/profile.jpg" },
+                { "artistId": 2, "name": "홍길동", "profileImageUrl": "https://image.url/profile1.jpg" }
+              ]}
+            }
+            """;
+
+        // when
+        var mvc = mockMvc.perform(get("/api/artists")
+                        .accept(MediaType.APPLICATION_JSON)).andReturn();
+
+        // then
+        String actual = mvc.getResponse().getContentAsString();
+        JSONAssert.assertEquals(expected, actual, true);
+    }
+
+    @Test
+    void 특정_아티스트_조회() throws Exception {
+
+        // given
+        var item = new ArtistsResponseDto(1L, "이지금", "https://image.url/profile.jpg");
+        given(artistsService.getArtistById(1L)).willReturn(item);
+
+        String expected = """
+            {
+              "status": 200,
+              "message": "아티스트 조회 성공",
+              "data": {
+                "artistId": 1,
+                "name": "이지금",
+                "profileImageUrl": "https://image.url/profile.jpg"
+              }
+            }
+            """;
+
+        // when
+        var mvc = mockMvc.perform(get("/api/artists/{id}", 1L)
+                        .accept(MediaType.APPLICATION_JSON)).andReturn();
+
+        // then
+        String actual = mvc.getResponse().getContentAsString();
+        JSONAssert.assertEquals(expected, actual, true);
+    }
+
+}


### PR DESCRIPTION
- 아티스트 전체 조회 구현
<img width="567" height="460" alt="image" src="https://github.com/user-attachments/assets/395f6978-1ac4-45a0-820f-27d78389bcf4" />

- 특정 아티스트 조회 구현
<img width="567" height="442" alt="image" src="https://github.com/user-attachments/assets/5e19db9c-e8bd-4487-8e96-37c4a91b0060" />

- ArtistsControllerTest 구현 및 성공

<img width="499" height="51" alt="image" src="https://github.com/user-attachments/assets/45510939-0289-4b2f-9712-8bc71d848a58" />

- 미완성
예외처리는 아직 미구현으로 추후 구현할 예정